### PR TITLE
Bump requirements to point to micro-nova fork of pyamplipi

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,5 @@
   "domains": ["media_player"],
   "iot_class": "local_polling",
   "render_readme": true,
-  "requirements": ["zeroconf","pyamplipi==0.4.9","validators"]
+  "requirements": ["zeroconf","validators","pyamplipi==0.4.11"]
 }


### PR DESCRIPTION
This PR bumps the necessary pyamplipi version necessary for our HACS integration. It points instead to our main branch on our organisation fork. I'm not sure if there is anything else necessary here to indicate a version update to HACS? I'll try it out.

[reference on that string's formatting](https://developers.home-assistant.io/docs/creating_integration_manifest/#custom-requirements-during-development--testing). 