### PR TITLE
Actually pin pyamplipi==0.4.11

### DIFF
--- a/custom_components/amplipi/manifest.json
+++ b/custom_components/amplipi/manifest.json
@@ -3,7 +3,7 @@
   "name": "AmpliPi",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/amplipi",
-  "requirements": ["zeroconf","pyamplipi","validators"],
+  "requirements": ["zeroconf","pyamplipi==0.4.11","validators"],
   "ssdp": [],
   "zeroconf": ["_amplipi._tcp.local."],
   "homekit": {},

--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,4 @@
   "domains": ["media_player"],
   "iot_class": "local_polling",
   "render_readme": true,
-  "requirements": ["zeroconf","validators","pyamplipi==0.4.11"]
 }


### PR DESCRIPTION
We've had a spate of reports come in about blocking IO calls, and the `pyamplipi` library lacking the new PlayMedia object type.

```
2024-08-12 15:00:33.063 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to open with args ('/config/custom_components/amplipi/__init__.py', 'wb') inside the event loop by custom integration 'hacs' at custom_components/hacs/repositories/base.py, line 698: zip_file.extractall(self.content.path.local, extractable) (offender: /usr/local/lib/python3.12/zipfile/__init__.py, line 1801: open(targetpath, "wb") as target:), please create a bug report at https://github.com/hacs/integration/issues            
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#open                             Traceback (most recent call last):                                                                                                   File "<frozen runpy>", line 198, in _run_module_as_main       
[snip]
  File "/config/custom_components/amplipi/media_player.py", line 20, in <module>                                                   
    from pyamplipi.models import ZoneUpdate, Source, SourceUpdate, GroupUpdate, Stream, Group, Zone, Announcement, \               ImportError: cannot import name 'PlayMedia' from 'pyamplipi.models' (/usr/local/lib/python3.12/site-packages/pyamplipi/models.py)
```

It turns out the `requirements` key in `hacs.json` was misdirection and [not at all where one should be pinning requirements](https://hacs.xyz/docs/publish/start/#hacsjson). The proper place is [in the actual integration manifest](https://developers.home-assistant.io/docs/creating_integration_manifest/).

When we first modified this integration, we [un-pinned the version for development](https://github.com/micro-nova/hacs_amplipi/commit/2602bd45b421e41577087b31fa1595a2b2142359) and before we had actually published 0.4.11 of the `pyamplipi` library. However, this never got added back in. This caused completely new installs to work normally, because they would grab 0.4.11, but old installs would continue to use their 0.4.9 and encounter errors.

I've reproduced this and tested this fix in a fork in my personal account and it works, even on a box that prior had a broken AmpliPi integration and encountered the issues.