### PR TITLE
Add support for volume step +/- 1%

### DIFF
--- a/custom_components/amplipi/media_player.py
+++ b/custom_components/amplipi/media_player.py
@@ -7,7 +7,7 @@ from typing import List
 import validators
 from homeassistant.components import media_source
 from homeassistant.components.media_player import MediaPlayerDeviceClass, MediaPlayerEntity, SUPPORT_VOLUME_MUTE, \
-    SUPPORT_VOLUME_SET, SUPPORT_SELECT_SOURCE, SUPPORT_PLAY_MEDIA, SUPPORT_PLAY
+    SUPPORT_VOLUME_SET, SUPPORT_VOLUME_STEP, SUPPORT_SELECT_SOURCE, SUPPORT_PLAY_MEDIA, SUPPORT_PLAY
 from homeassistant.components.media_player.browse_media import (
     async_process_play_media_url,
 )
@@ -51,6 +51,7 @@ SUPPORT_AMPLIPI_ZONE = (
         SUPPORT_SELECT_SOURCE
         | SUPPORT_VOLUME_MUTE
         | SUPPORT_VOLUME_SET
+        | SUPPORT_VOLUME_STEP
         | SUPPORT_BROWSE_MEDIA
         | SUPPORT_PLAY_MEDIA
 )
@@ -176,6 +177,21 @@ class AmpliPiSource(MediaPlayerEntity):
                 )
             )
         )
+
+   async def async_volume_up(self) -> None:
+        if hasattr(self, "volume_up"):
+            await self.hass.async_add_executor_job(self.volume_up)
+            return
+        if self.volume_level is not None and self.volume_level < 1:
+            await self.async_set_volume_level(min(1, self.volume_level + 0.01))
+
+    async def async_volume_down(self) -> None:
+        if hasattr(self, "volume_down"):
+            await self.hass.async_add_executor_job(self.volume_down)
+            return
+        if self.volume_level is not None and self.volume_level > 0:
+            await self.async_set_volume_level(max(0, self.volume_level - 0.01))
+
 
     async def async_browse_media(self, media_content_type=None, media_content_id=None):
         """Implement the websocket media browsing helper."""

--- a/custom_components/amplipi/media_player.py
+++ b/custom_components/amplipi/media_player.py
@@ -634,6 +634,23 @@ class AmpliPiZone(MediaPlayerEntity):
                 vol_f=volume
             ))
 
+
+    async def async_volume_up(self):
+        if hasattr(self, "volume_up"):
+            await self.hass.async_add_executor_job(self.volume_up)
+            return
+
+        if self.volume_level is not None and self.volume_level < 1:
+            await self.async_set_volume_level(min(1, self.volume_level + 0.01))
+
+    async def async_volume_down(self):
+        if hasattr(self, "volume_down"):
+            await self.hass.async_add_executor_job(self.volume_down)
+            return
+
+        if self.volume_level is not None and self.volume_level > 0:
+            await self.async_set_volume_level(max(0, self.volume_level - 0.01))
+
     @property
     def supported_features(self):
         """Return flag of media commands that are supported."""

--- a/custom_components/amplipi/media_player.py
+++ b/custom_components/amplipi/media_player.py
@@ -160,7 +160,7 @@ class AmpliPiSource(MediaPlayerEntity):
         if volume is None:
             return
         _LOGGER.warning(f"setting volume to {volume}")
-        
+
         group = next(filter(lambda z: z.vol_f is not None, self._groups), None)
         zone = next(filter(lambda z: z.vol_f is not None, self._zones), None)
         if group is not None:
@@ -178,14 +178,14 @@ class AmpliPiSource(MediaPlayerEntity):
             )
         )
 
-   async def async_volume_up(self) -> None:
+   async def async_volume_up(self):
         if hasattr(self, "volume_up"):
             await self.hass.async_add_executor_job(self.volume_up)
             return
         if self.volume_level is not None and self.volume_level < 1:
             await self.async_set_volume_level(min(1, self.volume_level + 0.01))
 
-    async def async_volume_down(self) -> None:
+    async def async_volume_down(self):
         if hasattr(self, "volume_down"):
             await self.hass.async_add_executor_job(self.volume_down)
             return

--- a/custom_components/amplipi/media_player.py
+++ b/custom_components/amplipi/media_player.py
@@ -160,7 +160,7 @@ class AmpliPiSource(MediaPlayerEntity):
         if volume is None:
             return
         _LOGGER.warning(f"setting volume to {volume}")
-
+        
         group = next(filter(lambda z: z.vol_f is not None, self._groups), None)
         zone = next(filter(lambda z: z.vol_f is not None, self._zones), None)
         if group is not None:
@@ -178,10 +178,12 @@ class AmpliPiSource(MediaPlayerEntity):
             )
         )
 
-   async def async_volume_up(self):
+
+    async def async_volume_up(self):
         if hasattr(self, "volume_up"):
             await self.hass.async_add_executor_job(self.volume_up)
             return
+
         if self.volume_level is not None and self.volume_level < 1:
             await self.async_set_volume_level(min(1, self.volume_level + 0.01))
 
@@ -189,6 +191,7 @@ class AmpliPiSource(MediaPlayerEntity):
         if hasattr(self, "volume_down"):
             await self.hass.async_add_executor_job(self.volume_down)
             return
+
         if self.volume_level is not None and self.volume_level > 0:
             await self.async_set_volume_level(max(0, self.volume_level - 0.01))
 


### PR DESCRIPTION
This adds support for SUPPORT_VOLUME_STEP to the Zones so that the Home Assistant media_player +/- buttons will increment by 1%