### PR TITLE
Fix Install on new HACS

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "AmpliPi",
   "domains": ["media_player"],
   "iot_class": "local_polling",
-  "render_readme": true,
+  "render_readme": true
 }


### PR DESCRIPTION
Fix install on new HACS by removing the trailing comma in `hacs.json`.