### PR TITLE
Add mention of AmpliPi-HomeAssistant-Card to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The AmpliPi Media Player entities support:
 - On
 - PA
 
+## Optional Setup
+This component has an optional companion component that can be found at https://github.com/micro-nova/AmpliPi-HomeAssistant-Card if you wish to use home assistant as a ui for your AmpliPi software. You can install that by first installing the [MiniMediaPlayer](https://github.com/kalkih/mini-media-player) component which can be found by searching for it in the HACS searchbar, and then following the same installation guide as this component but replacing the repository link with https://github.com/micro-nova/AmpliPi-HomeAssistant-Card and with type "Dashboard"
+
 ## Credits
 
 Cursor graphics used in this document from [Freepik](https://www.freepik.com/).


### PR DESCRIPTION
Our internal Home Assistant uses a component that we made, a component that can only be used with this integration, that we do not mention inside of this integration. I've fixed this in this PR.