### PR TITLE
Update codeowners in manifest.json

### DIFF
--- a/custom_components/amplipi/manifest.json
+++ b/custom_components/amplipi/manifest.json
@@ -9,7 +9,7 @@
   "homekit": {},
   "dependencies": [],
   "codeowners": [
-    "@gabehealey"
+    "@micro-nova"
   ],
   "iot_class": "local_polling",
   "version": "1.0"


### PR DESCRIPTION
I assume the purpose of codeowners is to show you who to poke or yell at if things go wrong, Gabe Healey is not the one to bother with this project

The codeowners show up at the top of the installation dialogue in HACS, which is why this is relevant
![image](https://github.com/user-attachments/assets/126ef44e-2f96-4b77-a90a-baae8074dfc7)
