### PR TITLE
Make parent class for all entities

### DIFF
--- a/custom_components/amplipi/coordinator.py
+++ b/custom_components/amplipi/coordinator.py
@@ -1,0 +1,74 @@
+"""
+    AmpliPi API data coordinator
+    Used to synchronize the current AmpliPi state with all of the corresponding HA Entities
+"""
+from datetime import timedelta
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from .models import Status, Source, Zone, Group
+from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
+from .const import DOMAIN
+
+class AmpliPiCoordinator(DataUpdateCoordinator):
+    def __init__(self, hass, logger, config_entry, api):
+        super().__init__(
+            hass,
+            logger,
+            config_entry=config_entry,
+            name="hacs_amplipi",
+            update_interval=timedelta(seconds=2),
+            always_update=True
+        )
+        self.api = api
+
+    async def get_friendly_name(self, entity_id):
+        """Look up entity in hass.states and get the friendly name"""
+        state = self.hass.states.get(entity_id)
+        if state:
+            return state.attributes.get("friendly_name")
+        
+    async def get_entity_id_from_unique_id(self, unique_id: str):
+        """Gets entity_id from the entity registry using the unique_id"""
+        registry = async_get_entity_registry(self.hass)
+        for entry in registry.entities.values():
+            if entry.unique_id == unique_id:
+                return entry.entity_id
+        return None
+    
+    async def _async_update_data(self) -> Status:
+        """Fetch data from API endpoint and pre-process into lookup tables."""
+
+        async def build_entity(entity, kind: str, cls, original_name: str):
+            unique_id = f"{DOMAIN}_{kind}_{entity['id']}"
+            entity_id = await self.get_entity_id_from_unique_id(unique_id) or f"media_player.{unique_id}"
+            friendly_name = await self.get_friendly_name(entity_id) or original_name
+            return cls(
+                **entity,
+                original_name=original_name,
+                unique_id=unique_id,
+                entity_id=entity_id,
+                friendly_name=friendly_name,
+            )
+
+        try:
+            state = await self.api.get_status()
+            state = state.dict()
+
+            state["sources"] = [
+                await build_entity(entity, "source", Source, f"Source {entity['id'] + 1}")
+                for entity in state["sources"]
+            ]
+
+            state["zones"] = [
+                await build_entity(entity, "zone", Zone, entity["name"])
+                for entity in state["zones"]
+            ]
+
+            state["groups"] = [
+                await build_entity(entity, "group", Group, entity["name"])
+                for entity in state["groups"]
+            ]
+
+            return Status(**state)
+
+        except Exception as e:
+            raise UpdateFailed(f"Error fetching data: {e}")

--- a/custom_components/amplipi/models.py
+++ b/custom_components/amplipi/models.py
@@ -1,0 +1,30 @@
+from typing import List
+from pydantic import BaseModel
+from pyamplipi.models import Source as PySource, Group as PyGroup, Zone as PyZone, Status as PyStatus, Stream as PyStream
+
+class AmpliPiHAEntity(BaseModel):
+    """Map an AmpliPi Object as a HA Entity"""
+    original_name: str
+    unique_id: str
+    friendly_name: str
+    entity_id: str
+
+class Source(PySource, AmpliPiHAEntity):
+    """An audio source\nAlso includes some encoding relating to HomeAssistant, including the original name and unique id of the related entity"""
+
+class Stream(PyStream, AmpliPiHAEntity):
+    """Digital stream such as Pandora, AirPlay or Spotify\nAlso includes some encoding relating to HomeAssistant, including the original name and unique id of the related entity"""
+
+class Group(PyGroup, AmpliPiHAEntity):
+    """A group of zones that can share the same audio input and be controlled as a group ie. Upstairs. Volume, mute,
+    and source_id fields are aggregates of the member zones.\nAlso includes some encoding relating to HomeAssistant, including the original name and unique id of the related entity"""
+
+class Zone(PyZone, AmpliPiHAEntity):
+    """Audio output to a stereo pair of speakers, typically belonging to a room.\nAlso includes some encoding relating to HomeAssistant, including the original name and unique id of the related entity"""
+
+class Status(PyStatus):
+    """Collection of PyAmpliPi objects with the PyAmpliPiExtension mixin that allows calls to GET /api to have home assistant entity data encoded within"""
+    sources: List[Source] = []
+    zones: List[Zone] = []
+    group: List[Group] = []
+    


### PR DESCRIPTION
The goal of this PR has changed over time from codifying stream entities to simply laying the groundwork for such a change as to reduce the scope of this PR

Add parent class and plug it in everywhere necessary to ensure all entities are aware of new stream naming principles as well as provide access to helper functions