### PR TITLE
Google Calendar blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ The AmpliPi Media Player entities support:
 - PA
 
 ## Optional Setup
+
+### Cards
 This component has an optional companion component that can be found at https://github.com/micro-nova/AmpliPi-HomeAssistant-Card if you wish to use home assistant as a ui for your AmpliPi software. You can install that by first installing the [MiniMediaPlayer](https://github.com/kalkih/mini-media-player) component which can be found by searching for it in the HACS searchbar, and then following the same installation guide as this component but replacing the repository link with https://github.com/micro-nova/AmpliPi-HomeAssistant-Card and with type "Dashboard"
+
+### Blueprints
+This integration comes with a few blueprints that are installed automatically alongside the integration itself, but there are some that are more niche that need to be installed by the user. Go to https://github.com/micro-nova/hacs_amplipi/blob/main/custom_components/amplipi/blueprints/automation/optional to see what other blueprints exist that might pique your interest.
 
 ## Credits
 

--- a/custom_components/amplipi/blueprints/automation/default_installed/start_streaming.yaml
+++ b/custom_components/amplipi/blueprints/automation/default_installed/start_streaming.yaml
@@ -1,0 +1,90 @@
+blueprint:
+  name: "AmpliPi Start Streaming"
+  description: "Connect a Source to a Stream and assign Zone(s) to the Source.\nAfter filling out these sections, hit the three dots in the top right and hit 'Take Control' to set the triggers of the automation"
+  domain: automation
+  author: Micro-Nova
+
+  input:
+    source:
+      name: "Source"
+      description: "Select the source\nOptional, used to ensure the automation still works when all 4 sources are in use via overriding a connected stream"
+      default: "Any"
+      selector:
+        entity:
+          filter:
+            - device_class: receiver
+            - integration: AmpliPi
+
+    stream:
+      name: "Stream"
+      description: "Select the audio stream"
+      selector:
+        entity:
+          filter:
+            # "stream" is not a real media player device class, but that doesn't stop me from yielding "stream" from that property in AmpliPiStream
+            - device_class: "stream"
+            - integration: AmpliPi
+
+    zones:
+      name: "Zones"
+      description: "Select one or more zones/groups for audio output"
+      selector:
+        entity:
+          filter:
+            - device_class: speaker
+            - integration: AmpliPi
+          multiple: true
+
+    volume:
+      name: "Volume"
+      description: "Select what volume to start the zones on"
+      selector:
+        number:
+          min: 0
+          max: 1
+          step: 0.01
+          mode: slider
+
+mode: single
+
+action:
+  - service: media_player.select_source
+    target:
+      entity_id: !input stream
+    data:
+      source: !input source
+
+  - repeat:
+      for_each: !input zones
+      sequence:
+          
+        - service: media_player.volume_set
+          data:
+            volume_level: !input volume
+          target:
+            entity_id: "{{ repeat.item }}"
+
+        # Mute before connecting so that the second loop has the chance to turn the zones/groups on all at once
+        - service: media_player.volume_mute
+          target:
+            entity_id: "{{ repeat.item }}"
+          data:
+            is_volume_muted: true
+
+        - service: media_player.select_source
+          target:
+            entity_id: !input stream
+          data:
+            source: "{{ repeat.item }}"
+
+# A second repeat loop so that every zone is already connected with a volume set before all turning on at once
+# This reduces the chance of having the zones/groups turn on one by one with a noticable gap between them
+  - repeat:
+      for_each: !input zones
+      sequence:
+        - service: media_player.volume_mute
+          target:
+            entity_id: "{{ repeat.item }}"
+          data:
+            is_volume_muted: false
+            

--- a/custom_components/amplipi/blueprints/automation/default_installed/tts_announcement.yaml
+++ b/custom_components/amplipi/blueprints/automation/default_installed/tts_announcement.yaml
@@ -1,0 +1,41 @@
+blueprint:
+  name: "AmpliPi Announce"
+  description: "Easy to use announcement builder\nAfter filling out these sections, hit the three dots in the top right and hit 'Take Control' to set the triggers of the automation"
+  domain: automation
+  author: Micro-Nova
+
+  input:
+    message:
+      name: "Message"
+      description: "What would you like to announce?"
+      default: "Any"
+      selector:
+        text:
+          multiline: true
+
+    cache:
+      name: "Cache"
+      description: "Would you like to save the tts to the disk? Good if you expect to use this announcement often, bad if this is a one-off or uncommon announcement."
+      default: true
+      selector:
+        boolean:
+
+  variables:
+    amplipi_announce_entity: >
+      {% set entity = states.media_player
+        | selectattr('attributes.app_name', 'eq', 'AmpliPi Announcement Channel')
+        | map(attribute='entity_id')
+        | list
+        | first %}
+      {{ entity }}
+
+mode: single
+
+action:
+  - service: tts.speak
+    data:
+      cache: !input cache
+      media_player_entity_id: "{{ amplipi_announce_entity }}"
+      message: !input message
+    target:
+      entity_id: tts.google_translate_en_com

--- a/custom_components/amplipi/blueprints/automation/optional/google_calendar_announcement.yaml
+++ b/custom_components/amplipi/blueprints/automation/optional/google_calendar_announcement.yaml
@@ -1,0 +1,67 @@
+blueprint:
+  name: "AmpliPi + Google Calendar: Announce Upcoming Calendar Event"
+  description: "Announces upcoming calendar events over the AmpliPi Announcement Channel."
+  source_url: https://github.com/micro-nova/hacs_amplipi/blob/main/custom_components/amplipi/blueprints/automation/optional/google_calendar_announcement.yaml
+  domain: automation
+  author: Micro-Nova
+
+  input:
+    minutes:
+      name: "Announcement Timing"
+      description: "How many minutes before the event should the announcement occur?"
+      default: 10
+      selector:
+        number:
+          min: 1
+          step: 1
+          unit_of_measurement: minutes
+          mode: slider
+
+    calendar:
+      name: "Calendar"
+      description: "Which calendar should be monitored for events?"
+      selector:
+        entity:
+          filter:
+            - domain: calendar
+
+variables:
+  amplipi_announce_entity: >
+    {% set entity = states.media_player
+      | selectattr('attributes.app_name', 'eq', 'AmpliPi Announcement Channel')
+      | map(attribute='entity_id')
+      | list
+      | first %}
+    {{ entity }}
+
+  calendar_entity: !input calendar
+
+  minutes: !input minutes
+
+trigger:
+  - platform: time_pattern
+    minutes: "/1"
+
+condition:
+  - condition: template
+    value_template: >
+      {% set event = state_attr(calendar_entity, 'start_time') %}
+      {% if event %}
+        {% set start = as_timestamp(event) %}
+        {% set now = as_timestamp(now()) %}
+        {{ (minutes - 1) * 60 <= (start - now) <= (minutes * 60) }} # Provide a one minute window just so that the automation doesn't have to coincidentally happen on the exact right second
+      {% else %}
+        false
+      {% endif %}
+
+action:
+  - service: tts.speak
+    data:
+      cache: false
+      media_player_entity_id: "{{ amplipi_announce_entity }}"
+      message: >
+        Upcoming event "{{ state_attr(calendar_entity, 'message') }}" starts in {{ minutes }} minutes.
+    target:
+      entity_id: tts.google_translate_en_com
+
+mode: single


### PR DESCRIPTION
Add blueprint that works with home assistant's google calendar integration

Add optional and default_installed folders for automation blueprints

Change __init__.py to only automatically install the default_installed blueprints and leave the optional blueprints alone

Depends on https://www.home-assistant.io/integrations/google
