### PR TITLE
Add google calendar blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You can send a text-to-speech message to the PA system using automations as well
 To simplify this process, we've made a [blueprint](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmicro-nova%2Fhacs_amplipi%2Fblob%2Fmain%2Fcustom_components%2Famplipi%2Fblueprints%2Ftts_announcement.yaml) that pre-populates the two related entities so all you need to do is type a message and decide if it should be cached. Similarly to the Start Streaming blueprint, this blueprint doesn't come with any triggers, though here's a few examples of what you could do:
 - Place a button in the kitchen to be pressed when dinner is ready to let the whole family know
 - Set a time trigger so that you don't lose track of time, such as reminding you to go to bed or do some chore
-- Use with other integrations to make more specialty announcements, such as warning you when a calendar event is coming up
+- Use with other integrations to make more specialty announcements, such as [warning you when a calendar event is coming up](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2Fmicro-nova%2Fhacs_amplipi%2Fblob%2Fmain%2Fcustom_components%2Famplipi%2Fblueprints%2Fgoogle_calendar_announcement.yaml) (Note that you will need to install the [Google Calendar](https://www.home-assistant.io/integrations/google/) plugin to make use of the linked blueprint)
 
 ## Credits
 

--- a/custom_components/amplipi/blueprints/google_calendar_announcement,yaml
+++ b/custom_components/amplipi/blueprints/google_calendar_announcement,yaml
@@ -1,0 +1,65 @@
+blueprint:
+  name: "AmpliPi + Google Calendar: Announce Upcoming Calendar Event"
+  description: "Announces upcoming calendar events over the AmpliPi Announcement Channel."
+  source_url: https://github.com/micro-nova/hacs_amplipi/blob/main/custom_components/amplipi/blueprints/automation/optional/google_calendar_announcement.yaml
+  domain: automation
+  author: Micro-Nova
+
+  input:
+    minutes:
+      name: "Announcement Timing"
+      description: "How many minutes before the event should the announcement occur?"
+      default: 10
+      selector:
+        number:
+          min: 1
+          step: 1
+          unit_of_measurement: minutes
+          mode: slider
+
+    calendar:
+      name: "Calendar"
+      description: "Which calendar should be monitored for events?"
+      selector:
+        entity:
+          filter:
+            - domain: calendar
+
+variables:
+  amplipi_announce_entity: >
+    {% set entity = states.media_player
+      | selectattr('attributes.app_name', 'eq', 'AmpliPi Announcement Channel')
+      | map(attribute='entity_id')
+      | list
+      | first %}
+    {{ entity }}
+  calendar_entity: !input calendar
+
+  minutes: !input minutes
+
+trigger:
+  - platform: time_pattern
+    minutes: "/1"
+
+condition:
+  - condition: template
+    value_template: >
+      {% set event = state_attr(calendar_entity, 'start_time') %}
+      {% if event %}
+        {% set start = as_timestamp(event) %}
+        {% set now = as_timestamp(now()) %}
+        {{ (minutes - 1) * 60 <= (start - now) <= (minutes * 60) }} # Provide a one minute window just so that the automation doesn't have to coincidentally happen on the exact right second
+      {% else %}
+        false
+      {% endif %}
+action:
+  - service: tts.speak
+    data:
+      cache: false
+      media_player_entity_id: "{{ amplipi_announce_entity }}"
+      message: >
+        Upcoming event "{{ state_attr(calendar_entity, 'message') }}" starts in {{ minutes }} minutes.
+    target:
+      entity_id: tts.google_translate_en_com
+
+mode: single


### PR DESCRIPTION
Blueprint that makes announcements X minutes before an upcoming calendar event using the [Google Calendar integration](https://www.home-assistant.io/integrations/google/)