### PR TITLE
Minimum amplipi version

### DIFF
--- a/custom_components/amplipi/coordinator.py
+++ b/custom_components/amplipi/coordinator.py
@@ -97,7 +97,7 @@ class AmpliPiDataClient(DataUpdateCoordinator, AmpliPi):
 
             minimum_version = "0.4.7"
             if Version(self.data.version) < Version(minimum_version):
-                persistent_notification.create(self.hass, f"AmpliPi version must be at least {minimum_version}", "AmpliPi version too low", f"{self.data.version}_version_error")
+                persistent_notification.create(self.hass, f"AmpliPi version must be at least {minimum_version}, please go to http://amplipi.local:5001/update to correct this", "AmpliPi version too low", f"{self.data.version}_version_error")
 
             status = Status(**state)
             self.async_set_updated_data(status)

--- a/custom_components/amplipi/coordinator.py
+++ b/custom_components/amplipi/coordinator.py
@@ -4,9 +4,11 @@
 """
 from datetime import timedelta
 from typing import Optional, Union, Callable
+from packaging.version import Version
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
+from homeassistant.components import persistent_notification
 
 from pyamplipi.amplipi import AmpliPi
 from pyamplipi.models import SourceUpdate, ZoneUpdate, MultiZoneUpdate, GroupUpdate, PlayMedia, Announcement, Status as PyStatus, Source as PySource, Stream as PyStream, Group as PyGroup, Zone as PyZone, Status as PyStatus
@@ -92,6 +94,10 @@ class AmpliPiDataClient(DataUpdateCoordinator, AmpliPi):
                 await build_entity(entity, "stream", Stream, entity["name"])
                 for entity in state["streams"]
             ]
+
+            minimum_version = "0.4.7"
+            if Version(self.data.version) < Version(minimum_version):
+                persistent_notification.create(self.hass, f"AmpliPi version must be at least {minimum_version}", "AmpliPi version too low", f"{self.data.version}_version_error")
 
             status = Status(**state)
             self.async_set_updated_data(status)

--- a/custom_components/amplipi/coordinator.py
+++ b/custom_components/amplipi/coordinator.py
@@ -96,8 +96,9 @@ class AmpliPiDataClient(DataUpdateCoordinator, AmpliPi):
             ]
 
             minimum_version = "0.4.7"
-            if Version(self.data.version) < Version(minimum_version):
-                persistent_notification.create(self.hass, f"AmpliPi version must be at least {minimum_version}, please go to http://amplipi.local:5001/update to correct this", "AmpliPi version too low", f"{self.data.version}_version_error")
+            current_version = state["info"]["version"]
+            if Version(current_version) < Version(minimum_version):
+                persistent_notification.create(self.hass, f"AmpliPi version must be at least {minimum_version} to work properly, please go to http://amplipi.local:5001/update to correct this", "AmpliPi version too low", f"{current_version}_version_error")
 
             status = Status(**state)
             self.async_set_updated_data(status)


### PR DESCRIPTION
This new integration release will require AmpliPi version `0.4.7` at minimum, I intend to note this in the patch notes but I want this to be made extra clear for those who ignore patch notes and just click "update". This code can read and compare semantic versions to see if the installed version of AmpliPI is lower than the minimum, and makes a notification if an update is needed

This will be replaced by #49 in time, this is just a good stopgap for this update specifically