### PR TITLE
Remove broken async-await relationship to stop the loud warning prints

### DIFF
--- a/custom_components/amplipi/media_player.py
+++ b/custom_components/amplipi/media_player.py
@@ -1074,7 +1074,7 @@ class AmpliPiZone(AmpliPiMediaPlayer):
             "stream_connected": self._stream is not None
         }
 
-    async def _get_zone_ids(self) -> List[int]:
+    def _get_zone_ids(self) -> List[int]:
         if self._group is not None:
             state = self.coordinator.data
             zone_ids = []


### PR DESCRIPTION
<img width="676" height="612" alt="image" src="https://github.com/user-attachments/assets/0d438928-f43e-4f3d-b8fb-74609bd5da72" />
There was an unnecessarily asynchronous function that was loudly complaining about not being awaited in a necessarily synchronous function, this pr solves that by removing the async keyword that caused the print in the attached picture once every second