### PR TITLE
Add sane default to stream blueprint's volume field

### DIFF
--- a/custom_components/amplipi/blueprints/start_streaming.yaml
+++ b/custom_components/amplipi/blueprints/start_streaming.yaml
@@ -44,6 +44,7 @@ blueprint:
     volume:
       name: "Volume"
       description: "Select what volume to start the zones on"
+      default: 0.5
       selector:
         number:
           min: 0


### PR DESCRIPTION
I got distracted by having multiple PRs approved at once and forgot to add the default in #74